### PR TITLE
Added Info.plist keys to enable request and use of Location Services.

### DIFF
--- a/Scavenger/Info.plist
+++ b/Scavenger/Info.plist
@@ -2,8 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationUsageDescription</key>
+	<string>This application requires the use of Location Services.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This application requires the use of Location Services while it is running in foreground or background.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This application requires Location Services.</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Add Info.plist keys for Location Service.
NSLocationAlwaysUsageDescription
This application requires the use of Location Services while it is running in foreground or background.
NSLocationWhenInUseUsageDescription
This application requires Location Services.
Privacy - Location Usage Description
This application requires the use of Location Services.
